### PR TITLE
Fix grave accent for uppercase letters

### DIFF
--- a/us-altgr-intl.keylayout
+++ b/us-altgr-intl.keylayout
@@ -1,16 +1,16 @@
 <?xml version="1.1" encoding="UTF-8"?>
 <!DOCTYPE keyboard SYSTEM "file://localhost/System/Library/DTDs/KeyboardLayout.dtd">
-<!--Last edited by Ukelele version 359 on 2024-02-16 at 15:07 (WET)-->
-<keyboard group="126" id="-8340" name="us-altgr-intl" maxout="2">
+<!--Last edited by Ukelele version 396 on 2025-02-20 at 19:24 (CET)-->
+<keyboard group="126" id="-11214" name="us-altgr-intl" maxout="2">
     <layouts>
         <layout first="0" last="17" mapSet="16c" modifiers="f4"/>
-        <layout first="18" last="18" mapSet="994" modifiers="f4"/>
-        <layout first="21" last="23" mapSet="994" modifiers="f4"/>
-        <layout first="30" last="30" mapSet="994" modifiers="f4"/>
-        <layout first="194" last="194" mapSet="994" modifiers="f4"/>
-        <layout first="197" last="197" mapSet="994" modifiers="f4"/>
-        <layout first="200" last="201" mapSet="994" modifiers="f4"/>
-        <layout first="206" last="207" mapSet="994" modifiers="f4"/>
+        <layout first="18" last="18" mapSet="984" modifiers="f4"/>
+        <layout first="21" last="23" mapSet="984" modifiers="f4"/>
+        <layout first="30" last="30" mapSet="984" modifiers="f4"/>
+        <layout first="194" last="194" mapSet="984" modifiers="f4"/>
+        <layout first="197" last="197" mapSet="984" modifiers="f4"/>
+        <layout first="200" last="201" mapSet="984" modifiers="f4"/>
+        <layout first="206" last="207" mapSet="984" modifiers="f4"/>
     </layouts>
     <modifierMap id="f4" defaultIndex="7">
         <keyMapSelect mapIndex="0">
@@ -43,24 +43,24 @@
     </modifierMap>
     <keyMapSet id="16c">
         <keyMap index="0">
-            <key code="0" action="13"/>
-            <key code="1" action="s"/>
-            <key code="2" action="d"/>
+            <key code="0" action="a5"/>
+            <key code="1" action="a31"/>
+            <key code="2" action="a22"/>
             <key code="3" output="f"/>
-            <key code="4" action="h"/>
-            <key code="5" action="g"/>
-            <key code="6" action="z"/>
+            <key code="4" action="a24"/>
+            <key code="5" action="a23"/>
+            <key code="6" action="a34"/>
             <key code="7" output="x"/>
-            <key code="8" action="c"/>
+            <key code="8" action="a21"/>
             <key code="9" output="v"/>
             <key code="10" output="`"/>
             <key code="11" output="b"/>
             <key code="12" output="q"/>
-            <key code="13" action="w"/>
-            <key code="14" action="14"/>
-            <key code="15" action="r"/>
-            <key code="16" action="19"/>
-            <key code="17" action="t"/>
+            <key code="13" action="a33"/>
+            <key code="14" action="a6"/>
+            <key code="15" action="a30"/>
+            <key code="16" action="a11"/>
+            <key code="17" action="a32"/>
             <key code="18" output="1"/>
             <key code="19" output="2"/>
             <key code="20" output="3"/>
@@ -74,31 +74,29 @@
             <key code="28" output="8"/>
             <key code="29" output="0"/>
             <key code="30" output="]"/>
-            <key code="31" action="17"/>
-            <key code="32" action="18"/>
+            <key code="31" action="a9"/>
+            <key code="32" action="a10"/>
             <key code="33" output="["/>
-            <key code="34" action="15"/>
-            <key code="35" action="p"/>
+            <key code="34" action="a7"/>
+            <key code="35" action="a29"/>
             <key code="36" output="&#x000D;"/>
-            <key code="37" action="l"/>
-            <key code="38" action="j"/>
+            <key code="37" action="a27"/>
+            <key code="38" action="a25"/>
             <key code="39" output="&#x0027;"/>
-            <key code="40" action="k"/>
+            <key code="40" action="a26"/>
             <key code="41" output=";"/>
             <key code="42" output="\"/>
             <key code="43" output=","/>
             <key code="44" output="/"/>
-            <key code="45" action="16"/>
-            <key code="46" action="m"/>
+            <key code="45" action="a8"/>
+            <key code="46" action="a28"/>
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" action="5"/>
+            <key code="49" action="a15"/>
             <key code="50" output="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
-            <key code="56" output=""/>
-            <key code="58" output=""/>
             <key code="64" output="&#x0010;"/>
             <key code="65" output="."/>
             <key code="66" output="&#x001D;"/>
@@ -157,7 +155,7 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
         <keyMap index="1">
-            <key code="0" action="6"/>
+            <key code="0" action="a16"/>
             <key code="1" output="S"/>
             <key code="2" output="D"/>
             <key code="3" output="F"/>
@@ -171,9 +169,9 @@
             <key code="11" output="B"/>
             <key code="12" output="Q"/>
             <key code="13" output="W"/>
-            <key code="14" action="7"/>
+            <key code="14" action="a17"/>
             <key code="15" output="R"/>
-            <key code="16" action="12"/>
+            <key code="16" action="a4"/>
             <key code="17" output="T"/>
             <key code="18" output="!"/>
             <key code="19" output="@"/>
@@ -188,10 +186,10 @@
             <key code="28" output="*"/>
             <key code="29" output=")"/>
             <key code="30" output="}"/>
-            <key code="31" action="10"/>
-            <key code="32" action="11"/>
+            <key code="31" action="a2"/>
+            <key code="32" action="a3"/>
             <key code="33" output="{"/>
-            <key code="34" action="8"/>
+            <key code="34" action="a18"/>
             <key code="35" output="P"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" output="L"/>
@@ -202,11 +200,11 @@
             <key code="42" output="|"/>
             <key code="43" output="&#x003C;"/>
             <key code="44" output="?"/>
-            <key code="45" action="9"/>
+            <key code="45" action="a19"/>
             <key code="46" output="M"/>
             <key code="47" output="&#x003E;"/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" action="5"/>
+            <key code="49" action="a15"/>
             <key code="50" output="~"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
@@ -269,7 +267,7 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
         <keyMap index="2">
-            <key code="0" action="6"/>
+            <key code="0" action="a16"/>
             <key code="1" output="S"/>
             <key code="2" output="D"/>
             <key code="3" output="F"/>
@@ -283,9 +281,9 @@
             <key code="11" output="B"/>
             <key code="12" output="Q"/>
             <key code="13" output="W"/>
-            <key code="14" action="7"/>
+            <key code="14" action="a17"/>
             <key code="15" output="R"/>
-            <key code="16" action="12"/>
+            <key code="16" action="a4"/>
             <key code="17" output="T"/>
             <key code="18" output="1"/>
             <key code="19" output="2"/>
@@ -300,10 +298,10 @@
             <key code="28" output="8"/>
             <key code="29" output="0"/>
             <key code="30" output="]"/>
-            <key code="31" action="10"/>
-            <key code="32" action="11"/>
+            <key code="31" action="a2"/>
+            <key code="32" action="a3"/>
             <key code="33" output="["/>
-            <key code="34" action="8"/>
+            <key code="34" action="a18"/>
             <key code="35" output="P"/>
             <key code="36" output="&#x000D;"/>
             <key code="37" output="L"/>
@@ -314,11 +312,11 @@
             <key code="42" output="\"/>
             <key code="43" output=","/>
             <key code="44" output="/"/>
-            <key code="45" action="9"/>
+            <key code="45" action="a19"/>
             <key code="46" output="M"/>
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" action="5"/>
+            <key code="49" action="a15"/>
             <key code="50" output="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
@@ -391,7 +389,7 @@
             <key code="7" output="œ"/>
             <key code="8" output="©"/>
             <key code="9" output="®"/>
-            <key code="10" action="`"/>
+            <key code="10" action="a20"/>
             <key code="11" output=""/>
             <key code="12" output="ä"/>
             <key code="13" output="å"/>
@@ -403,13 +401,13 @@
             <key code="19" output="²"/>
             <key code="20" output="³"/>
             <key code="21" output="¤"/>
-            <key code="22" action="̂"/>
+            <key code="22" action="a37"/>
             <key code="23" output="€"/>
             <key code="24" output="×"/>
             <key code="25" output="‘"/>
-            <key code="26" action="̛"/>
+            <key code="26" action="a46"/>
             <key code="27" output="¥"/>
-            <key code="28" action="̨"/>
+            <key code="28" action="a49"/>
             <key code="29" output="’"/>
             <key code="30" output="»"/>
             <key code="31" output="ó"/>
@@ -420,7 +418,7 @@
             <key code="36" output="&#x000D;"/>
             <key code="37" output="ø"/>
             <key code="38" output="ï"/>
-            <key code="39" action="́"/>
+            <key code="39" action="a36"/>
             <key code="40" output="œ"/>
             <key code="41" output="¶"/>
             <key code="42" output="¬"/>
@@ -428,10 +426,10 @@
             <key code="44" output="¿"/>
             <key code="45" output="ñ"/>
             <key code="46" output="µ"/>
-            <key code="47" action="̇"/>
+            <key code="47" action="a40"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output=" "/>
-            <key code="50" action="`"/>
+            <key code="50" action="a20"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -503,7 +501,7 @@
             <key code="7" output="Œ"/>
             <key code="8" output="¢"/>
             <key code="9" output="®"/>
-            <key code="10" action="~"/>
+            <key code="10" action="a35"/>
             <key code="11" output=""/>
             <key code="12" output="Ä"/>
             <key code="13" output="Å"/>
@@ -512,17 +510,17 @@
             <key code="16" output="Ü"/>
             <key code="17" output="Þ"/>
             <key code="18" output="¡"/>
-            <key code="19" action="̋"/>
-            <key code="20" action="̄"/>
+            <key code="19" action="a44"/>
+            <key code="20" action="a38"/>
             <key code="21" output="£"/>
             <key code="22" output="¼"/>
-            <key code="23" action="̧"/>
+            <key code="23" action="a48"/>
             <key code="24" output="÷"/>
-            <key code="25" action="̆"/>
+            <key code="25" action="a39"/>
             <key code="26" output="½"/>
-            <key code="27" action="̣"/>
+            <key code="27" action="a47"/>
             <key code="28" output="¾"/>
-            <key code="29" action="̊"/>
+            <key code="29" action="a43"/>
             <key code="30" output="”"/>
             <key code="31" output="Ó"/>
             <key code="32" output="Ú"/>
@@ -532,18 +530,18 @@
             <key code="36" output="&#x000D;"/>
             <key code="37" output="Ø"/>
             <key code="38" output="Ï"/>
-            <key code="39" action="̈"/>
+            <key code="39" action="a41"/>
             <key code="40" output="Œ"/>
             <key code="41" output="°"/>
             <key code="42" output="¦"/>
             <key code="43" output="Ç"/>
-            <key code="44" action="̉"/>
+            <key code="44" action="a42"/>
             <key code="45" output="Ñ"/>
             <key code="46" output="µ"/>
-            <key code="47" action="̌"/>
+            <key code="47" action="a45"/>
             <key code="48" output="&#x0009;"/>
             <key code="49" output=" "/>
-            <key code="50" action="~"/>
+            <key code="50" action="a35"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
             <key code="53" output="&#x001B;"/>
@@ -878,7 +876,7 @@
             <key code="46" output="&#x000D;"/>
             <key code="47" output="."/>
             <key code="48" output="&#x0009;"/>
-            <key code="49" action="5"/>
+            <key code="49" action="a15"/>
             <key code="50" output="`"/>
             <key code="51" output="&#x0008;"/>
             <key code="52" output="&#x0003;"/>
@@ -941,7 +939,7 @@
             <key code="126" output="&#x001E;"/>
         </keyMap>
     </keyMapSet>
-    <keyMapSet id="994">
+    <keyMapSet id="984">
         <keyMap index="0" baseMapSet="16c" baseIndex="0">
             <key code="24" output="^"/>
             <key code="30" output="["/>
@@ -951,8 +949,8 @@
             <key code="93" output="¥"/>
             <key code="94" output="_"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="a15"/>
+            <key code="104" action="a15"/>
         </keyMap>
         <keyMap index="1" baseMapSet="16c" baseIndex="1">
             <key code="19" output="&#x0022;"/>
@@ -971,8 +969,8 @@
             <key code="93" output="|"/>
             <key code="94" output="_"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="a15"/>
+            <key code="104" action="a15"/>
         </keyMap>
         <keyMap index="2" baseMapSet="16c" baseIndex="2">
             <key code="24" output="^"/>
@@ -983,405 +981,415 @@
             <key code="93" output="¥"/>
             <key code="94" output="_"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="a15"/>
+            <key code="104" action="a15"/>
         </keyMap>
         <keyMap index="3" baseMapSet="16c" baseIndex="3">
             <key code="93" output="\"/>
-            <key code="94" action="1"/>
+            <key code="94" action="a1"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="a15"/>
+            <key code="104" action="a15"/>
         </keyMap>
         <keyMap index="4" baseMapSet="16c" baseIndex="4">
             <key code="93" output="|"/>
             <key code="94" output="`"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="a15"/>
+            <key code="104" action="a15"/>
         </keyMap>
         <keyMap index="5" baseMapSet="16c" baseIndex="5">
             <key code="93" output="\"/>
             <key code="94" output="`"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="a15"/>
+            <key code="104" action="a15"/>
         </keyMap>
         <keyMap index="6" baseMapSet="16c" baseIndex="6">
             <key code="93" output="\"/>
             <key code="94" output="_"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="a15"/>
+            <key code="104" action="a15"/>
         </keyMap>
         <keyMap index="7" baseMapSet="16c" baseIndex="7">
             <key code="93" output="|"/>
             <key code="94" output="_"/>
             <key code="95" output=","/>
-            <key code="102" action="5"/>
-            <key code="104" action="5"/>
+            <key code="102" action="a15"/>
+            <key code="104" action="a15"/>
         </keyMap>
     </keyMapSet>
     <actions>
-        <action id="0">
-            <when state="none" next="s1"/>
+        <action id="a0">
+            <when state="none" next="17"/>
         </action>
-        <action id="1">
-            <when state="none" next="s2"/>
+        <action id="a1">
+            <when state="none" next="20"/>
         </action>
-        <action id="10">
-            <when state="none" output="O"/>
-            <when state="s1" output="Ó"/>
-            <when state="s2" output="Ò"/>
-            <when state="s3" output="Ô"/>
-            <when state="s4" output="Ö"/>
-            <when state="s5" output="Õ"/>
-        </action>
-        <action id="11">
-            <when state="none" output="U"/>
-            <when state="s1" output="Ú"/>
-            <when state="s2" output="Ù"/>
-            <when state="s3" output="Û"/>
-            <when state="s4" output="Ü"/>
-        </action>
-        <action id="12">
-            <when state="none" output="Y"/>
-            <when state="s4" output="Ÿ"/>
-        </action>
-        <action id="13">
-            <when state="none" output="a"/>
-            <when state="dead_abovedot" output="ȧ"/>
-            <when state="dead_abovering" output="å"/>
-            <when state="dead_acute" output="á"/>
-            <when state="dead_belowdot" output="ạ"/>
-            <when state="dead_breve" output="ă"/>
-            <when state="dead_caron" output="ǎ"/>
-            <when state="dead_cedilla" output="a̧"/>
-            <when state="dead_circumflex" output="â"/>
-            <when state="dead_diaresis" output="ä"/>
-            <when state="dead_grave" output="à"/>
-            <when state="dead_hook" output=" ả"/>
-            <when state="dead_macron" output="ā"/>
-            <when state="dead_ogonek" output="ą"/>
-            <when state="dead_tilde" output="ã"/>
-            <when state="s1" output="á"/>
-            <when state="s2" output="à"/>
-            <when state="s3" output="â"/>
-            <when state="s4" output="ä"/>
-            <when state="s5" output="ã"/>
-        </action>
-        <action id="14">
-            <when state="none" output="e"/>
-            <when state="dead_abovedot" output="ė"/>
-            <when state="dead_acute" output="é"/>
-            <when state="dead_belowdot" output="ẹ"/>
-            <when state="dead_breve" output="ĕ"/>
-            <when state="dead_caron" output="ě"/>
-            <when state="dead_cedilla" output="ȩ"/>
-            <when state="dead_circumflex" output="ê"/>
-            <when state="dead_diaresis" output="ë"/>
-            <when state="dead_grave" output="è"/>
-            <when state="dead_hook" output="ẻ"/>
-            <when state="dead_horn" output="e̛"/>
-            <when state="dead_macron" output="ē"/>
-            <when state="dead_ogonek" output="ę"/>
-            <when state="dead_tilde" output="ẽ"/>
-            <when state="s1" output="é"/>
-            <when state="s2" output="è"/>
-            <when state="s3" output="ê"/>
-            <when state="s4" output="ë"/>
-        </action>
-        <action id="15">
-            <when state="none" output="i"/>
-            <when state="dead_abovedot" output="ı"/>
-            <when state="dead_acute" output="í"/>
-            <when state="dead_belowdot" output="ị"/>
-            <when state="dead_breve" output="ĭ"/>
-            <when state="dead_caron" output="ǐ"/>
-            <when state="dead_circumflex" output="î"/>
-            <when state="dead_diaresis" output="ï"/>
-            <when state="dead_grave" output="ì"/>
-            <when state="dead_hook" output="ỉ"/>
-            <when state="dead_macron" output="ī"/>
-            <when state="dead_ogonek" output="į"/>
-            <when state="dead_tilde" output="ĩ"/>
-            <when state="s1" output="í"/>
-            <when state="s2" output="ì"/>
-            <when state="s3" output="î"/>
-            <when state="s4" output="ï"/>
-        </action>
-        <action id="16">
-            <when state="none" output="n"/>
-            <when state="dead_abovedot" output="ṅ"/>
-            <when state="dead_acute" output="ń"/>
-            <when state="dead_belowdot" output="ṇ"/>
-            <when state="dead_caron" output="ň"/>
-            <when state="dead_grave" output="ǹ"/>
-            <when state="dead_tilde" output="ñ"/>
-            <when state="s5" output="ñ"/>
-        </action>
-        <action id="17">
-            <when state="none" output="o"/>
-            <when state="dead_abovedot" output="ȯ"/>
-            <when state="dead_acute" output="ó"/>
-            <when state="dead_belowdot" output="ọ"/>
-            <when state="dead_breve" output="ŏ"/>
-            <when state="dead_caron" output="ǒ"/>
-            <when state="dead_cedilla" output="o̧"/>
-            <when state="dead_circumflex" output="ô"/>
-            <when state="dead_diaresis" output="ö"/>
-            <when state="dead_doubleacute" output="ő"/>
-            <when state="dead_grave" output="ò"/>
-            <when state="dead_hook" output="ỏ"/>
-            <when state="dead_horn" output="ơ"/>
-            <when state="dead_macron" output="ō"/>
-            <when state="dead_ogonek" output="ǫ"/>
-            <when state="dead_tilde" output="õ"/>
-            <when state="s1" output="ó"/>
-            <when state="s2" output="ò"/>
-            <when state="s3" output="ô"/>
-            <when state="s4" output="ö"/>
-            <when state="s5" output="õ"/>
-        </action>
-        <action id="18">
+        <action id="a10">
             <when state="none" output="u"/>
-            <when state="dead_abovering" output="ů"/>
-            <when state="dead_acute" output="ú"/>
-            <when state="dead_belowdot" output="ụ"/>
-            <when state="dead_breve" output="ŭ"/>
-            <when state="dead_caron" output="ǔ"/>
-            <when state="dead_cedilla" output="u̧"/>
-            <when state="dead_circumflex" output="û"/>
-            <when state="dead_diaresis" output="ü"/>
-            <when state="dead_doubleacute" output="ű"/>
-            <when state="dead_grave" output="ù"/>
-            <when state="dead_hook" output="ủ"/>
-            <when state="dead_horn" output="ư"/>
-            <when state="dead_macron" output="ū"/>
-            <when state="dead_ogonek" output="ų"/>
-            <when state="dead_tilde" output="ũ"/>
-            <when state="s1" output="ú"/>
-            <when state="s2" output="ù"/>
-            <when state="s3" output="û"/>
-            <when state="s4" output="ü"/>
+            <when state="1" output="û"/>
+            <when state="10" output="ų"/>
+            <when state="12" output="u̧"/>
+            <when state="13" output="ư"/>
+            <when state="15" output="ü"/>
+            <when state="16" output="ů"/>
+            <when state="17" output="ú"/>
+            <when state="18" output="ű"/>
+            <when state="19" output="ụ"/>
+            <when state="2" output="ǔ"/>
+            <when state="20" output="ù"/>
+            <when state="21" output="ū"/>
+            <when state="3" output="ủ"/>
+            <when state="4" output="ũ"/>
+            <when state="5" output="ú"/>
+            <when state="6" output="ü"/>
+            <when state="7" output="ŭ"/>
+            <when state="8" output="û"/>
+            <when state="9" output="ù"/>
         </action>
-        <action id="19">
+        <action id="a11">
             <when state="none" output="y"/>
-            <when state="dead_abovedot" output="ẏ"/>
-            <when state="dead_abovering" output="ẙ"/>
-            <when state="dead_acute" output="ý"/>
-            <when state="dead_belowdot" output="ỵ"/>
-            <when state="dead_circumflex" output="ŷ"/>
-            <when state="dead_diaresis" output="ÿ"/>
-            <when state="dead_grave" output="ỳ"/>
-            <when state="dead_hook" output="ỷ"/>
-            <when state="dead_macron" output="ȳ"/>
-            <when state="dead_tilde" output="ỹ"/>
-            <when state="s4" output="ÿ"/>
+            <when state="14" output="ẏ"/>
+            <when state="15" output="ÿ"/>
+            <when state="16" output="ẙ"/>
+            <when state="19" output="ỵ"/>
+            <when state="21" output="ȳ"/>
+            <when state="3" output="ỷ"/>
+            <when state="4" output="ỹ"/>
+            <when state="5" output="ý"/>
+            <when state="6" output="ÿ"/>
+            <when state="8" output="ŷ"/>
+            <when state="9" output="ỳ"/>
         </action>
-        <action id="2">
-            <when state="none" next="s3"/>
+        <action id="a12">
+            <when state="none" next="1"/>
         </action>
-        <action id="3">
-            <when state="none" next="s4"/>
+        <action id="a13">
+            <when state="none" next="6"/>
         </action>
-        <action id="4">
-            <when state="none" next="s5"/>
+        <action id="a14">
+            <when state="none" next="11"/>
         </action>
-        <action id="5">
+        <action id="a15">
             <when state="none" output=" "/>
-            <when state="s1" output="´"/>
-            <when state="s2" output="`"/>
-            <when state="s3" output="ˆ"/>
-            <when state="s4" output="¨"/>
-            <when state="s5" output="˜"/>
+            <when state="1" output="ˆ"/>
+            <when state="11" output="˜"/>
+            <when state="17" output="´"/>
+            <when state="20" output="`"/>
+            <when state="6" output="¨"/>
         </action>
-        <action id="6">
+        <action id="a16">
             <when state="none" output="A"/>
-            <when state="s1" output="Á"/>
-            <when state="s2" output="À"/>
-            <when state="s3" output="Â"/>
-            <when state="s4" output="Ä"/>
-            <when state="s5" output="Ã"/>
+            <when state="1" output="Â"/>
+            <when state="11" output="Ã"/>
+            <when state="17" output="Á"/>
+            <when state="20" output="À"/>
+            <when state="5" output="Á"/>
+            <when state="6" output="Ä"/>
+            <when state="9" output="À"/>
         </action>
-        <action id="7">
+        <action id="a17">
             <when state="none" output="E"/>
-            <when state="s1" output="É"/>
-            <when state="s2" output="È"/>
-            <when state="s3" output="Ê"/>
-            <when state="s4" output="Ë"/>
+            <when state="1" output="Ê"/>
+            <when state="17" output="É"/>
+            <when state="20" output="È"/>
+            <when state="5" output="É"/>
+            <when state="6" output="Ë"/>
+            <when state="9" output="È"/>
         </action>
-        <action id="8">
+        <action id="a18">
             <when state="none" output="I"/>
-            <when state="s1" output="Í"/>
-            <when state="s2" output="Ì"/>
-            <when state="s3" output="Î"/>
-            <when state="s4" output="Ï"/>
+            <when state="1" output="Î"/>
+            <when state="17" output="Í"/>
+            <when state="20" output="Ì"/>
+            <when state="5" output="Í"/>
+            <when state="6" output="Ï"/>
+            <when state="9" output="Ì"/>
         </action>
-        <action id="9">
+        <action id="a19">
             <when state="none" output="N"/>
-            <when state="s5" output="Ñ"/>
+            <when state="11" output="Ñ"/>
         </action>
-        <action id="`">
-            <when state="none" next="dead_grave"/>
+        <action id="a2">
+            <when state="none" output="O"/>
+            <when state="1" output="Ô"/>
+            <when state="11" output="Õ"/>
+            <when state="17" output="Ó"/>
+            <when state="20" output="Ò"/>
+            <when state="5" output="Ó"/>
+            <when state="6" output="Ö"/>
+            <when state="9" output="Ò"/>
         </action>
-        <action id="c">
+        <action id="a20">
+            <when state="none" next="9"/>
+        </action>
+        <action id="a21">
             <when state="none" output="c"/>
-            <when state="dead_abovedot" output="ċ"/>
-            <when state="dead_acute" output="ć"/>
-            <when state="dead_belowdot" output="c̣"/>
-            <when state="dead_caron" output="č"/>
-            <when state="dead_cedilla" output="ç"/>
-            <when state="dead_circumflex" output="ĉ"/>
+            <when state="12" output="ç"/>
+            <when state="14" output="ċ"/>
+            <when state="19" output="c̣"/>
+            <when state="2" output="č"/>
+            <when state="5" output="ć"/>
+            <when state="8" output="ĉ"/>
         </action>
-        <action id="d">
+        <action id="a22">
             <when state="none" output="d"/>
-            <when state="dead_caron" output="ď"/>
+            <when state="2" output="ď"/>
         </action>
-        <action id="g">
+        <action id="a23">
             <when state="none" output="g"/>
-            <when state="dead_abovedot" output="ġ"/>
-            <when state="dead_acute" output="ǵ"/>
-            <when state="dead_breve" output="ğ"/>
-            <when state="dead_caron" output="ǧ"/>
-            <when state="dead_circumflex" output="ĝ"/>
+            <when state="14" output="ġ"/>
+            <when state="2" output="ǧ"/>
+            <when state="5" output="ǵ"/>
+            <when state="7" output="ğ"/>
+            <when state="8" output="ĝ"/>
         </action>
-        <action id="h">
+        <action id="a24">
             <when state="none" output="h"/>
-            <when state="dead_caron" output="ȟ"/>
+            <when state="2" output="ȟ"/>
         </action>
-        <action id="j">
+        <action id="a25">
             <when state="none" output="j"/>
-            <when state="dead_caron" output="ǰ"/>
+            <when state="2" output="ǰ"/>
         </action>
-        <action id="k">
+        <action id="a26">
             <when state="none" output="k"/>
-            <when state="dead_acute" output="ḱ"/>
-            <when state="dead_belowdot" output="ḳ"/>
-            <when state="dead_caron" output="ǩ"/>
+            <when state="19" output="ḳ"/>
+            <when state="2" output="ǩ"/>
+            <when state="5" output="ḱ"/>
         </action>
-        <action id="l">
+        <action id="a27">
             <when state="none" output="l"/>
-            <when state="dead_acute" output="ĺ"/>
-            <when state="dead_belowdot" output="ḷ"/>
-            <when state="dead_caron" output="ľ"/>
+            <when state="19" output="ḷ"/>
+            <when state="2" output="ľ"/>
+            <when state="5" output="ĺ"/>
         </action>
-        <action id="m">
+        <action id="a28">
             <when state="none" output="m"/>
-            <when state="dead_abovedot" output="ṁ"/>
-            <when state="dead_acute" output="ḿ"/>
-            <when state="dead_belowdot" output="ṃ"/>
+            <when state="14" output="ṁ"/>
+            <when state="19" output="ṃ"/>
+            <when state="5" output="ḿ"/>
         </action>
-        <action id="p">
+        <action id="a29">
             <when state="none" output="p"/>
-            <when state="dead_abovedot" output="ṗ"/>
-            <when state="dead_acute" output="ṕ"/>
+            <when state="14" output="ṗ"/>
+            <when state="5" output="ṕ"/>
         </action>
-        <action id="r">
+        <action id="a3">
+            <when state="none" output="U"/>
+            <when state="1" output="Û"/>
+            <when state="17" output="Ú"/>
+            <when state="20" output="Ù"/>
+            <when state="5" output="Ú"/>
+            <when state="6" output="Ü"/>
+            <when state="9" output="Ù"/>
+        </action>
+        <action id="a30">
             <when state="none" output="r"/>
-            <when state="dead_abovedot" output="ṙ"/>
-            <when state="dead_acute" output="ŕ"/>
-            <when state="dead_belowdot" output="ṛ"/>
-            <when state="dead_caron" output="ř"/>
+            <when state="14" output="ṙ"/>
+            <when state="19" output="ṛ"/>
+            <when state="2" output="ř"/>
+            <when state="5" output="ŕ"/>
         </action>
-        <action id="s">
+        <action id="a31">
             <when state="none" output="s"/>
-            <when state="dead_abovedot" output="ṡ"/>
-            <when state="dead_acute" output="ś"/>
-            <when state="dead_belowdot" output="ṣ"/>
-            <when state="dead_caron" output="š"/>
-            <when state="dead_cedilla" output="ş"/>
-            <when state="dead_circumflex" output="ŝ"/>
+            <when state="12" output="ş"/>
+            <when state="14" output="ṡ"/>
+            <when state="19" output="ṣ"/>
+            <when state="2" output="š"/>
+            <when state="5" output="ś"/>
+            <when state="8" output="ŝ"/>
         </action>
-        <action id="t">
+        <action id="a32">
             <when state="none" output="t"/>
-            <when state="dead_caron" output="ť"/>
+            <when state="2" output="ť"/>
         </action>
-        <action id="w">
+        <action id="a33">
             <when state="none" output="w"/>
-            <when state="dead_abovedot" output="ẇ"/>
-            <when state="dead_abovering" output="ẘ"/>
-            <when state="dead_acute" output="ẃ"/>
-            <when state="dead_belowdot" output="ẉ"/>
-            <when state="dead_circumflex" output="ŵ"/>
-            <when state="dead_diaresis" output="ẅ"/>
-            <when state="dead_grave" output="ẁ"/>
+            <when state="14" output="ẇ"/>
+            <when state="15" output="ẅ"/>
+            <when state="16" output="ẘ"/>
+            <when state="19" output="ẉ"/>
+            <when state="5" output="ẃ"/>
+            <when state="8" output="ŵ"/>
+            <when state="9" output="ẁ"/>
         </action>
-        <action id="z">
+        <action id="a34">
             <when state="none" output="z"/>
-            <when state="dead_abovedot" output="ż"/>
-            <when state="dead_acute" output="ź"/>
-            <when state="dead_belowdot" output="ẓ"/>
-            <when state="dead_caron" output="ž"/>
-            <when state="dead_circumflex" output="ẑ"/>
+            <when state="14" output="ż"/>
+            <when state="19" output="ẓ"/>
+            <when state="2" output="ž"/>
+            <when state="5" output="ź"/>
+            <when state="8" output="ẑ"/>
         </action>
-        <action id="~">
-            <when state="none" next="dead_tilde"/>
+        <action id="a35">
+            <when state="none" next="4"/>
         </action>
-        <action id="́">
-            <when state="none" next="dead_acute"/>
+        <action id="a36">
+            <when state="none" next="5"/>
         </action>
-        <action id="̂">
-            <when state="none" next="dead_circumflex"/>
+        <action id="a37">
+            <when state="none" next="8"/>
         </action>
-        <action id="̄">
-            <when state="none" next="dead_macron"/>
+        <action id="a38">
+            <when state="none" next="21"/>
         </action>
-        <action id="̆">
-            <when state="none" next="dead_breve"/>
+        <action id="a39">
+            <when state="none" next="7"/>
         </action>
-        <action id="̇">
-            <when state="none" next="dead_abovedot"/>
+        <action id="a4">
+            <when state="none" output="Y"/>
+            <when state="6" output="Ÿ"/>
         </action>
-        <action id="̈">
-            <when state="none" next="dead_diaresis"/>
+        <action id="a40">
+            <when state="none" next="14"/>
         </action>
-        <action id="̉">
-            <when state="none" next="dead_hook"/>
+        <action id="a41">
+            <when state="none" next="15"/>
         </action>
-        <action id="̊">
-            <when state="none" next="dead_abovering"/>
+        <action id="a42">
+            <when state="none" next="3"/>
         </action>
-        <action id="̋">
-            <when state="none" next="dead_doubleacute"/>
+        <action id="a43">
+            <when state="none" next="16"/>
         </action>
-        <action id="̌">
-            <when state="none" next="dead_caron"/>
+        <action id="a44">
+            <when state="none" next="18"/>
         </action>
-        <action id="̛">
-            <when state="none" next="dead_horn"/>
+        <action id="a45">
+            <when state="none" next="2"/>
         </action>
-        <action id="̣">
-            <when state="none" next="dead_belowdot"/>
+        <action id="a46">
+            <when state="none" next="13"/>
         </action>
-        <action id="̧">
-            <when state="none" next="dead_cedilla"/>
+        <action id="a47">
+            <when state="none" next="19"/>
         </action>
-        <action id="̨">
-            <when state="none" next="dead_ogonek"/>
+        <action id="a48">
+            <when state="none" next="12"/>
+        </action>
+        <action id="a49">
+            <when state="none" next="10"/>
+        </action>
+        <action id="a5">
+            <when state="none" output="a"/>
+            <when state="1" output="â"/>
+            <when state="10" output="ą"/>
+            <when state="11" output="ã"/>
+            <when state="12" output="a̧"/>
+            <when state="14" output="ȧ"/>
+            <when state="15" output="ä"/>
+            <when state="16" output="å"/>
+            <when state="17" output="á"/>
+            <when state="19" output="ạ"/>
+            <when state="2" output="ǎ"/>
+            <when state="20" output="à"/>
+            <when state="21" output="ā"/>
+            <when state="3" output=" ả"/>
+            <when state="4" output="ã"/>
+            <when state="5" output="á"/>
+            <when state="6" output="ä"/>
+            <when state="7" output="ă"/>
+            <when state="8" output="â"/>
+            <when state="9" output="à"/>
+        </action>
+        <action id="a6">
+            <when state="none" output="e"/>
+            <when state="1" output="ê"/>
+            <when state="10" output="ę"/>
+            <when state="12" output="ȩ"/>
+            <when state="13" output="e̛"/>
+            <when state="14" output="ė"/>
+            <when state="15" output="ë"/>
+            <when state="17" output="é"/>
+            <when state="19" output="ẹ"/>
+            <when state="2" output="ě"/>
+            <when state="20" output="è"/>
+            <when state="21" output="ē"/>
+            <when state="3" output="ẻ"/>
+            <when state="4" output="ẽ"/>
+            <when state="5" output="é"/>
+            <when state="6" output="ë"/>
+            <when state="7" output="ĕ"/>
+            <when state="8" output="ê"/>
+            <when state="9" output="è"/>
+        </action>
+        <action id="a7">
+            <when state="none" output="i"/>
+            <when state="1" output="î"/>
+            <when state="10" output="į"/>
+            <when state="14" output="ı"/>
+            <when state="15" output="ï"/>
+            <when state="17" output="í"/>
+            <when state="19" output="ị"/>
+            <when state="2" output="ǐ"/>
+            <when state="20" output="ì"/>
+            <when state="21" output="ī"/>
+            <when state="3" output="ỉ"/>
+            <when state="4" output="ĩ"/>
+            <when state="5" output="í"/>
+            <when state="6" output="ï"/>
+            <when state="7" output="ĭ"/>
+            <when state="8" output="î"/>
+            <when state="9" output="ì"/>
+        </action>
+        <action id="a8">
+            <when state="none" output="n"/>
+            <when state="11" output="ñ"/>
+            <when state="14" output="ṅ"/>
+            <when state="19" output="ṇ"/>
+            <when state="2" output="ň"/>
+            <when state="4" output="ñ"/>
+            <when state="5" output="ń"/>
+            <when state="9" output="ǹ"/>
+        </action>
+        <action id="a9">
+            <when state="none" output="o"/>
+            <when state="1" output="ô"/>
+            <when state="10" output="ǫ"/>
+            <when state="11" output="õ"/>
+            <when state="12" output="o̧"/>
+            <when state="13" output="ơ"/>
+            <when state="14" output="ȯ"/>
+            <when state="15" output="ö"/>
+            <when state="17" output="ó"/>
+            <when state="18" output="ő"/>
+            <when state="19" output="ọ"/>
+            <when state="2" output="ǒ"/>
+            <when state="20" output="ò"/>
+            <when state="21" output="ō"/>
+            <when state="3" output="ỏ"/>
+            <when state="4" output="õ"/>
+            <when state="5" output="ó"/>
+            <when state="6" output="ö"/>
+            <when state="7" output="ŏ"/>
+            <when state="8" output="ô"/>
+            <when state="9" output="ò"/>
         </action>
     </actions>
     <terminators>
-        <when state="dead_abovedot" output="˙"/>
-        <when state="dead_abovering" output="˚"/>
-        <when state="dead_acute" output="´"/>
-        <when state="dead_belowdot" output="."/>
-        <when state="dead_breve" output="˘"/>
-        <when state="dead_caron" output="ˇ"/>
-        <when state="dead_cedilla" output="¸"/>
-        <when state="dead_circumflex" output="^"/>
-        <when state="dead_diaresis" output="¨"/>
-        <when state="dead_doubleacute" output="˝"/>
-        <when state="dead_grave" output="`"/>
-        <when state="dead_hook" output="◌̉"/>
-        <when state="dead_horn" output="◌̛"/>
-        <when state="dead_macron" output="ˉ"/>
-        <when state="dead_ogonek" output="˛"/>
-        <when state="dead_tilde" output="~"/>
-        <when state="s1" output="´"/>
-        <when state="s2" output="`"/>
-        <when state="s3" output="ˆ"/>
-        <when state="s4" output="¨"/>
-        <when state="s5" output="˜"/>
+        <when state="1" output="ˆ"/>
+        <when state="10" output="˛"/>
+        <when state="11" output="˜"/>
+        <when state="12" output="¸"/>
+        <when state="13" output="◌̛"/>
+        <when state="14" output="˙"/>
+        <when state="15" output="¨"/>
+        <when state="16" output="˚"/>
+        <when state="17" output="´"/>
+        <when state="18" output="˝"/>
+        <when state="19" output="."/>
+        <when state="2" output="ˇ"/>
+        <when state="20" output="`"/>
+        <when state="21" output="ˉ"/>
+        <when state="3" output="◌̉"/>
+        <when state="4" output="~"/>
+        <when state="5" output="´"/>
+        <when state="6" output="¨"/>
+        <when state="7" output="˘"/>
+        <when state="8" output="^"/>
+        <when state="9" output="`"/>
     </terminators>
 </keyboard>


### PR DESCRIPTION
This changes fixes #3.

I modified the keyboard layout using Ukelele to enable grave accent support for all vowels in uppercase form, specifically: `À`, `È`, `Ì`, `Ò`, and `Ù`. Additionally, the layout now supports acute accents: `Á`, `É`, `Í`, `Ó`, and `Ú`.

The accents can be applied when the user enters a dead key state and uses the `Shift` key for uppercase letters. For example, to type `Ó` sequence is: `AltGr+´` `Shift + O`.

I have included before-and-after screenshots for reference. Ukelele seems to change the file a lot. 😩

![state-5-before](https://github.com/user-attachments/assets/4240cb84-75b1-48af-9faf-631599a894d7)
![state-5-after](https://github.com/user-attachments/assets/b92068f4-42d9-4395-a1d4-f99657713ef8)

---

![state-9-before](https://github.com/user-attachments/assets/ef0a123e-0309-40da-8832-c3873d7fdc7c)
![state-9-after](https://github.com/user-attachments/assets/95697a56-1e87-48dd-993c-73e00181dae3)
